### PR TITLE
Fix missing pkgs in module imports

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,22 +22,14 @@
           specialArgs = { inherit inputs; };
           modules = [
             ./hosts/dragonfly/configuration.nix
-            (import ./modules {
-              inherit inputs;
-              pkgs = nixpkgs;
-              lib = nixpkgs.lib;
-            })
+            (import ./modules { inherit inputs; })
           ];
         };
         killi = nixpkgs.lib.nixosSystem {
           specialArgs = { inherit inputs nixpkgs; };
           modules = [
             ./hosts/killi/configuration.nix
-            (import ./modules {
-              inherit inputs;
-              pkgs = nixpkgs;
-              lib = nixpkgs.lib;
-            })
+            (import ./modules { inherit inputs; })
           ];
         };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -22,14 +22,14 @@
           specialArgs = { inherit inputs; };
           modules = [
             ./hosts/dragonfly/configuration.nix
-            (import ./modules { inherit inputs; })
+            ./modules
           ];
         };
         killi = nixpkgs.lib.nixosSystem {
           specialArgs = { inherit inputs nixpkgs; };
           modules = [
             ./hosts/killi/configuration.nix
-            (import ./modules { inherit inputs; })
+            ./modules
           ];
         };
       };

--- a/modules/desktop.nix
+++ b/modules/desktop.nix
@@ -33,6 +33,7 @@
       xserver = {
         enable = true;
         displayManager.gdm.enable = true;
+        displayManager.sessionPackages = [ pkgs.hyprland ];
         xkb.layout = "fr";
       };
     };


### PR DESCRIPTION
## Summary
- fix flake to pass the correct pkgs when importing local modules

## Testing
- `nix flake show` *(fails: `nix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6841e16aac80832fb898ef9d3b09c2d2